### PR TITLE
Adding user configurable socket options

### DIFF
--- a/dss_datamover/client_application.py
+++ b/dss_datamover/client_application.py
@@ -312,7 +312,7 @@ class ClientApplication(object):
         prctl.set_proctitle(name)
 
         try:
-            socket = ServerSocket(self.logger, self.ip_address_family)
+            socket = ServerSocket(self.config, self.logger, self.ip_address_family)
             socket_index_address = "{}:{}".format(self.ip_address, self.port_index)
             socket.bind(self.ip_address, self.port_index)
             self.logger.info("Client Index-Monitor listening to - {}".format(socket_index_address))
@@ -444,7 +444,7 @@ class ClientApplication(object):
 
         try:
             socket_address = "tcp://{}:{}".format(self.ip_address, self.port_status)
-            socket = ServerSocket(self.logger, self.ip_address_family)
+            socket = ServerSocket(self.config, self.logger, self.ip_address_family)
             socket.bind(self.ip_address, self.port_status)
             socket.accept()
             self.logger.info("Monitor-Status Socket Address-{}".format(socket_address))

--- a/dss_datamover/config/config.json
+++ b/dss_datamover/config/config.json
@@ -17,6 +17,12 @@
     "port_status": 6001
   },
   "ip_address_family" : "IPV6",
+  "socket_options": {
+    "connection_delay_interval": 2,
+    "connection_time_threshold": 300,
+    "message_length": 10,
+    "recv_timeout": 60
+  },
   "fs_config":{
                "mounted": false,
                "nfs": {

--- a/dss_datamover/config/config.json
+++ b/dss_datamover/config/config.json
@@ -18,9 +18,9 @@
   },
   "ip_address_family" : "IPV6",
   "socket_options": {
-    "connection_delay_interval": 2,
-    "connection_time_threshold": 300,
-    "message_length": 10,
+    "connection_retry_delay": 2,
+    "max_connection_time_threshold": 300,
+    "response_header_length": 10,
     "recv_timeout": 60
   },
   "fs_config":{

--- a/dss_datamover/monitor.py
+++ b/dss_datamover/monitor.py
@@ -205,7 +205,7 @@ class Monitor(object):
         successful_socket_connection = 0
         for client in self.clients:
             try:
-                client.socket_index = ClientSocket(self.logger, self.ip_address_family)
+                client.socket_index = ClientSocket(self.config, self.logger, self.ip_address_family)
                 client.socket_index.connect(client.ip_address, client.port_index)
                 successful_socket_connection += 1
                 self.logger.info("Monitor-Index-Distributor: Connected to Monitor-Index-MessageHandler of ClientApp-{}:{}".format(client.id, client.port_index))
@@ -394,7 +394,7 @@ class Monitor(object):
         successful_socket_connection = 0
         for client in self.clients:
             try:
-                client.socket_status = ClientSocket(self.logger, self.ip_address_family)
+                client.socket_status = ClientSocket(self.config, self.logger, self.ip_address_family)
                 client.socket_status.connect(client.ip_address, client.port_status)
                 self.logger.info("Monitor-Status-Poller: Connected to ClientApp-{}:{}".format(
                     client.id, client.port_status))


### PR DESCRIPTION
Users are now able to set socket options from the datamover config file

```
"socket_options": {
    "connection_delay_interval": 2,
    "connection_time_threshold": 300,
    "message_length": 10,
    "recv_timeout": 60
  },
```
![image](https://user-images.githubusercontent.com/10873980/217402051-ac9ed652-c90e-42cd-bdf8-c2b0b006e67a.png)

Data Mover Put operation ran successfully.

![image](https://user-images.githubusercontent.com/10873980/217402119-2a11ce12-050b-4dcc-b9c3-d7299fd29c2c.png)
