### PR TITLE
Graceful exit of DM application when supplied with invalid prefix

### DIFF
--- a/dss_datamover/nfs_cluster.py
+++ b/dss_datamover/nfs_cluster.py
@@ -86,6 +86,7 @@ class NFSCluster:
         cluster_ip = prefix[0:first_delimiter_pos]
         ret = -1
         nfs_share = ""
+        console = ""
         for nfs_share in self.config[cluster_ip]:
             nfs_share_prefix = cluster_ip + nfs_share
             if prefix.startswith(nfs_share_prefix):
@@ -93,7 +94,7 @@ class NFSCluster:
                         and nfs_share in self.local_mounts[cluster_ip]):
                     self.logger.info("Prefix -{} is already mounted to {}".format(
                         prefix, "/" + nfs_share_prefix))
-                    return cluster_ip, nfs_share, 0
+                    return cluster_ip, nfs_share, 0, console
                 else:
                     ret, console = self.mount(cluster_ip, nfs_share)
                 break
@@ -101,7 +102,7 @@ class NFSCluster:
             self.logger.info("Mounted NFS shares {}:{}".format(cluster_ip, nfs_share))
             self.nfs_cluster.append(cluster_ip)
 
-        return cluster_ip, nfs_share, ret
+        return cluster_ip, nfs_share, ret, console
 
     @exception
     def mount(self, cluster_ip, nfs_share):


### PR DESCRIPTION
This contains the fix for MIN-1312 :: Allows for the graceful exit of DataMover when supplied with invalid prefix during PUT operation.

SS for DM runs for different use cases, after fix is attached herewith...
1. When prefix specification is wrong:
<img width="956" alt="wrong_prefix_specs" src="https://user-images.githubusercontent.com/91374706/221231839-657d40b9-39ee-4d87-8c10-6cdee9b69fde.PNG">

2. When prefix specification is correct but does not match Config entries:
<img width="957" alt="prefix_not_match_config" src="https://user-images.githubusercontent.com/91374706/221232146-b359d5b5-0366-4ac3-a844-dfc088680d94.PNG">

3. When prefix specification & Config entries are correct but the prefix specified File/Directory is not present:
<img width="954" alt="prefix_no_file_directory" src="https://user-images.githubusercontent.com/91374706/221232688-8c5e9789-5dc4-4907-ad11-67d940cac5d8.PNG">

4. When all good:
<img width="955" alt="correct_prefix_config_entry_1" src="https://user-images.githubusercontent.com/91374706/221232850-a283cd6f-53cd-416f-81c0-b32d2ed8c620.PNG">
<img width="601" alt="correct_prefix_config_entry_2" src="https://user-images.githubusercontent.com/91374706/221232884-a741588f-30d8-468c-83b3-22ad9797d4a7.PNG">
