### PR TITLE
Fix for MIN-1312: Graceful exit of DataMover for invalid prefix

### DIFF
--- a/dss_datamover/nfs_cluster.py
+++ b/dss_datamover/nfs_cluster.py
@@ -86,6 +86,7 @@ class NFSCluster:
         cluster_ip = prefix[0:first_delimiter_pos]
         ret = -1
         nfs_share = ""
+        console = ""
         for nfs_share in self.config[cluster_ip]:
             nfs_share_prefix = cluster_ip + nfs_share
             if prefix.startswith(nfs_share_prefix):
@@ -93,7 +94,7 @@ class NFSCluster:
                         and nfs_share in self.local_mounts[cluster_ip]):
                     self.logger.info("Prefix -{} is already mounted to {}".format(
                         prefix, "/" + nfs_share_prefix))
-                    return cluster_ip, nfs_share, 0
+                    return cluster_ip, nfs_share, 0, console
                 else:
                     ret, console = self.mount(cluster_ip, nfs_share)
                 break
@@ -101,7 +102,7 @@ class NFSCluster:
             self.logger.info("Mounted NFS shares {}:{}".format(cluster_ip, nfs_share))
             self.nfs_cluster.append(cluster_ip)
 
-        return cluster_ip, nfs_share, ret
+        return cluster_ip, nfs_share, ret, console
 
     @exception
     def mount(self, cluster_ip, nfs_share):

--- a/dss_datamover/utils/utility.py
+++ b/dss_datamover/utils/utility.py
@@ -206,17 +206,34 @@ def get_s3_prefix(logger, nfs_cluster, prefix=None):
             yield nfs_server_ip + "/"
 
 
-def validate_s3_prefix(logger, prefix):
+def validate_s3_prefix(logger, prefix, config_nfs=None):
     """
     Validate a given prefix. A S3 prefix should start without "/" and end with "/".
     <prefix string>/
     :param logger: multiprocessing logger object
     :param prefix: a string
+    :param(optional) config_nfs: nfs_share Config dict
     :return: Success/Failure
     """
+    inv_prefix = 0
     if prefix.startswith("/") or not prefix.endswith("/"):
-        logger.error("WRONG specification of prefix. Should be in the format of <nfs_server_ip>/<prefix>/ ")
+        logger.fatal("WRONG specification of prefix. Should be in the format of <nfs_server_ip>/<prefix>/ ")
         return False
+    if config_nfs is not None:
+        cluster_ip = prefix.split('/')[0]
+        if config_nfs and cluster_ip in config_nfs:
+            for nfs_share in config_nfs[cluster_ip]:
+                nfs_share_prefix = cluster_ip + nfs_share
+                if not prefix.startswith(nfs_share_prefix):
+                    inv_prefix += 1
+            if inv_prefix == len(config_nfs[cluster_ip]):
+                logger.fatal("Specified Prefix: {} does not match any entry in the Config file nfs_share list: "
+                             "{}.".format(prefix, config_nfs[cluster_ip]))
+                return False
+        else:
+            logger.fatal("Specified Prefix IP: {} does not match any entry in the Config file nfs_share IP list: {}."
+                         .format(cluster_ip, config_nfs))
+            return False
     return True
 
 

--- a/dss_datamover/utils/utility.py
+++ b/dss_datamover/utils/utility.py
@@ -215,18 +215,19 @@ def validate_s3_prefix(logger, prefix, config_nfs=None):
     :param(optional) config_nfs: nfs_share Config dict
     :return: Success/Failure
     """
-    inv_prefix = 0
+    inv_prefix = False
     if prefix.startswith("/") or not prefix.endswith("/"):
         logger.fatal("WRONG specification of prefix. Should be in the format of <nfs_server_ip>/<prefix>/ ")
         return False
-    if config_nfs is not None:
+    if config_nfs:
         cluster_ip = prefix.split('/')[0]
-        if config_nfs and cluster_ip in config_nfs:
+        if cluster_ip in config_nfs:
             for nfs_share in config_nfs[cluster_ip]:
                 nfs_share_prefix = cluster_ip + nfs_share
-                if not prefix.startswith(nfs_share_prefix):
-                    inv_prefix += 1
-            if inv_prefix == len(config_nfs[cluster_ip]):
+                if prefix.startswith(nfs_share_prefix):
+                    inv_prefix = True
+                    break
+            if not inv_prefix:
                 logger.fatal("Specified Prefix: {} does not match any entry in the Config file nfs_share list: "
                              "{}.".format(prefix, config_nfs[cluster_ip]))
                 return False


### PR DESCRIPTION
This contains the fix for MIN-1312 :: Allows for the graceful exit of DataMover when supplied with invalid prefix during PUT operation.

SS for DM runs for different use cases, after fix is attached herewith...
1. When prefix specification is wrong:
![image](https://user-images.githubusercontent.com/91374706/221519709-3faac04e-3df5-4c44-a104-fff5ff7e803f.png)

2. When prefix specification is correct but does not match Config entries:
![image](https://user-images.githubusercontent.com/91374706/221519651-ff38fb54-cd4c-49c1-b1b8-71b83334b01b.png)

3. When prefix specification & Config entries are correct but the prefix specified File/Directory is not present:
![image](https://user-images.githubusercontent.com/91374706/221519560-7a173258-bbe7-4e6e-93db-787e68501a15.png)
![image](https://user-images.githubusercontent.com/91374706/221520328-ecafc943-5edc-4da2-93b8-2becc26ba687.png)
![image](https://user-images.githubusercontent.com/91374706/221520509-2872b207-d82a-48c1-bb63-9d18aaad6489.png)

4. GET operation with invalid prefix:
![image](https://user-images.githubusercontent.com/91374706/221521188-7a317055-68ff-4ee1-95dc-af8a023e0edf.png)
![image](https://user-images.githubusercontent.com/91374706/221521421-4ff802d1-6586-4573-8d1d-cb34a7d4916f.png)

5. DEL operation with invalid prefix:
![image](https://user-images.githubusercontent.com/91374706/221521816-e5a2bebb-da73-4efe-89ed-a3eb5fe23004.png)
![image](https://user-images.githubusercontent.com/91374706/221521998-a963b50a-3cd8-49fa-ba16-f3f469642682.png)

6. LIST operation with invalid prefix:
![image](https://user-images.githubusercontent.com/91374706/221522403-14d38f8f-7bb8-47a4-9ee8-fdb56b85e993.png)

7. When all good:
![image](https://user-images.githubusercontent.com/91374706/221519409-56f36a90-5e5f-4af6-a595-3a15ad967e25.png)
![image](https://user-images.githubusercontent.com/91374706/221519298-a6f02e3b-f410-481b-85ed-94fb8d83c596.png)