### PR TITLE
.NET tests: init version

### DIFF
--- a/dss_client/include/dss.h
+++ b/dss_client/include/dss.h
@@ -7,9 +7,11 @@ extern "C" {
 typedef void* DSSClient;
 DSSClient DSSClientInit(char *ip, char* user, char* passwd, char* uuid, int endpoints_per_cluster);
 int GetObjectBuffer(DSSClient c, void* key, int key_len, unsigned char* buffer, long int buffer_size);
-int GetObject(DSSClient c, void* key, int key_len, char* dst_file);
 int PutObjectBuffer(DSSClient c, void* key, int key_len, unsigned char* buffer, long int content_length);
+int GetObject(DSSClient c, void* key, int key_len, char* dst_file);
+int PutObject(DSSClient c, void* key, int key_len, char* src_file);
 int DeleteObject(DSSClient c, void* key, int key_len);
+char* ListObjects(DSSClient c, char* prefix, char* delimit);
 
 #ifdef __cplusplus
 }

--- a/dss_client/include/dss_client.hpp
+++ b/dss_client/include/dss_client.hpp
@@ -42,7 +42,7 @@
 namespace dss {
 	namespace py = pybind11;
 
-#define DSS_VER    "20210217"
+#define DSS_VER    "71d317f"
 #define DSS_PAGINATION_DEFAULT	100UL
 
 	class Endpoint;

--- a/dss_client/test/dotnet_test_app/.gitignore
+++ b/dss_client/test/dotnet_test_app/.gitignore
@@ -1,0 +1,5 @@
+bin
+obj
+*.result
+*.o
+*.so

--- a/dss_client/test/dotnet_test_app/Program.cs
+++ b/dss_client/test/dotnet_test_app/Program.cs
@@ -62,7 +62,7 @@ unsafe public class Tester
                 string get_res0_fn = "get1.result";
                 string get_res1_fn = "get2.result";
                 int size = 1024*1024; // 1024 KB 1MB
-                string fname = "/home/pengfei.xu/wksp/data/random_2G.txt";
+                string fname = "path_of_your_local_file";
                 Console.WriteLine("---------------C#: test the creation of dss client -------------");
                 void* dss_client = DSSClientInit(end_point, name, psw, "12345", 256);
                 if (dss_client == null) {Console.WriteLine("Client creation Failed"); return;}

--- a/dss_client/test/dotnet_test_app/Program.cs
+++ b/dss_client/test/dotnet_test_app/Program.cs
@@ -1,0 +1,112 @@
+using System;
+ 
+using System.Runtime.InteropServices;
+
+using System.Diagnostics;
+
+using System.Security.Cryptography; // for System.Security.Cryptography.MD5
+
+unsafe public class Tester
+{
+        public const string dss_lib = "libdss.so";
+        [DllImport(dss_lib, EntryPoint="DSSClientInit")]
+        unsafe static extern void* DSSClientInit(string end_point, string access_key, string secret_key, string uuid, int name_len);
+        [DllImport(dss_lib, EntryPoint="PutObjectBuffer")]
+        unsafe static extern int PutObjectBuffer(void* dss_client, string key, int key_len, byte[] buf, long buf_size);
+
+        [DllImport(dss_lib, EntryPoint="GetObjectBuffer")]
+        unsafe static extern int GetObjectBuffer(void* dss_client, string key, int key_len, byte* buf, long buf_size);
+
+        [DllImport(dss_lib, EntryPoint="GetObject")]
+        static extern int GetObject(void* dss_client, string key, int key_len, string dest_fn);
+        [DllImport(dss_lib, EntryPoint="PutObject")]
+        static extern int PutObject(void* dss_client, string key, int key_len, string src_fn);
+
+        [DllImport(dss_lib, EntryPoint="DeleteObject")]
+        static extern int DeleteObject(void* dss_client, string key, int key_len);
+        [DllImport(dss_lib, EntryPoint="ListObjects")]
+        unsafe static extern IntPtr ListObjects(void* dss_client, string prefix, string delimit);
+        static public string CalculateMD5(string filename)
+        {
+                using (var md5 = MD5.Create())
+                {
+                        using (var stream = File.OpenRead(filename))
+                        {
+                                var hash = md5.ComputeHash(stream);
+                                return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
+                                // return BitConverter.ToString(hash);
+                        }
+                }
+        }
+
+        static void DisplayKeys(IntPtr char_ptr){
+                string managedString = Marshal.PtrToStringAnsi(char_ptr);
+                string[] keys = managedString.Remove(managedString.Length-1,1).Split('\n');
+                foreach (var key in keys)
+                {
+                        Console.WriteLine($"obj: {key}");
+                }
+        }
+
+        unsafe static public void Main(string[] args)
+        {
+                if (args.Length < 3){
+                        Console.WriteLine("Please use valid args: <endpoint_url> <access_key> <secret_key>");
+                        return;
+                }
+                string end_point = args[0];
+                string name= args[1];
+                string psw = args[2];
+                string obj_key0 = "exp0";
+                string obj_key1 = "exp1";
+                string get_res0_fn = "get1.result";
+                string get_res1_fn = "get2.result";
+                int size = 1024*1024; // 1024 KB 1MB
+                string fname = "/home/pengfei.xu/wksp/data/random_2G.txt";
+                Console.WriteLine("---------------C#: test the creation of dss client -------------");
+                void* dss_client = DSSClientInit(end_point, name, psw, "12345", 256);
+                if (dss_client == null) {Console.WriteLine("Client creation Failed"); return;}
+                Console.WriteLine("---------------creation of dss client: PASSED -------------");
+                Console.WriteLine("---------------C#: test GetObjectBuffer/PutObjectBuffer -------------");
+                byte[] input_of_put = File.ReadAllBytes(fname);
+                if (PutObjectBuffer(dss_client, obj_key0, obj_key0.Length, input_of_put, size) < 0){
+                        Console.WriteLine("PutObjectBuffer Failedfor {}", obj_key0); return;}
+                byte* output_of_get = stackalloc byte[size];
+                if (GetObjectBuffer(dss_client, obj_key0, obj_key0.Length, output_of_get, size) < 0){
+                        Console.WriteLine("GetObjectBuffer Failed for {}", obj_key0); return;}
+                for (int i=0;i < size; i++){
+                        Debug.Assert(input_of_put[i]==output_of_get[i], "GET/PUT result mismatch");
+                }
+                Console.WriteLine("---------------C#: GetObjectBuffer/PutObjectBuffer: PASSED -------------");
+                Console.WriteLine("---------------C#: GetObject/PutObject -------------");
+                int ret_get0 = GetObject(dss_client, obj_key0, obj_key0.Length, get_res0_fn);
+                string s0 = CalculateMD5(get_res0_fn);
+                Console.WriteLine("{0}: {1}", get_res0_fn, s0);
+                PutObject(dss_client,  obj_key1, obj_key1.Length, get_res0_fn);
+                int ret_get1 = GetObject(dss_client, obj_key1, obj_key1.Length, get_res1_fn);
+                string s1 = CalculateMD5(get_res1_fn);
+                Console.WriteLine("{0}: {1}", get_res1_fn, s1);
+                Debug.Assert(s0.Equals(s1), "GET/PUT result mismatch");
+                Console.WriteLine("---------------C#: GetObject/PutObject: PASSED -------------");
+                Console.WriteLine("---------------C#: DeleteObject/ListObjects -------------");
+                byte* buf_before_delete = stackalloc byte[size];
+                if (GetObjectBuffer(dss_client, obj_key0, obj_key0.Length, buf_before_delete, size) < 0){
+                        Console.WriteLine("GetObjectBuffer Failed for {0}", obj_key0); return;
+                }
+                Debug.Assert(buf_before_delete!=null, string.Format("failed to get the object {0}, choose another key to delete", obj_key0 ) );
+                Console.WriteLine("before delete");
+                IntPtr charPtr = ListObjects(dss_client, "ex", "/");
+                DisplayKeys(charPtr);
+                Console.WriteLine("after delete");
+                DeleteObject(dss_client, obj_key0, obj_key0.Length);
+                IntPtr charPtr2 = ListObjects(dss_client, "e", "/");
+                DisplayKeys(charPtr2);
+                byte* buf_unreachable = stackalloc byte[size];
+                if (GetObjectBuffer(dss_client, obj_key0, obj_key0.Length, buf_unreachable, size) < 0){ // expected to fail: "Exception caught in GetObjectBuffer for exp0"
+                        Console.WriteLine("GetObjectBuffer Failed for {0}", obj_key0);
+                }
+                Marshal.FreeCoTaskMem(charPtr);
+                Marshal.FreeCoTaskMem(charPtr2);
+                Console.WriteLine("---------------C#: DeleteObject/ListObjects: PASSED -------------");
+        }
+}

--- a/dss_client/test/dotnet_test_app/README.md
+++ b/dss_client/test/dotnet_test_app/README.md
@@ -1,0 +1,24 @@
+# Test the .NET Application
+
+
+## Requirements
+
+- CentOS 7.x
+- GCC
+- DSS cluster deployed with the DSS client library
+- .NET 
+
+## Install .NET
+
+
+```shell
+sudo rpm -Uvh https://packages.microsoft.com/config/centos/7/packages-microsoft-prod.rpm && \
+sudo yum install dotnet-sdk-7.0
+```
+
+
+## Compile the .NET project and run the test
+
+```shell
+LD_LIBRARY_PATH=/usr/dss/client-library dotnet run "http://msl-ssg-vm03-tcp-0:9000" "minio" "minio123"
+```

--- a/dss_client/test/dotnet_test_app/c_to_dotnet.csproj
+++ b/dss_client/test/dotnet_test_app/c_to_dotnet.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
1. Added two extern C functions (ListObjects & PutObject) for testing the .NET application.
2. Included a simple .NET application to test GetObjectBuffer/PutObjectBuffer, GetObject/PutObject, DeleteObject, ListObjects. Tested working for object size <= 1GB. Needs review for confirming the correctness & updating the test code.
3. C wrapper at the .NET application end is removed.
4. "unsafe" is required for the zero-copy feature. As we have discussed before, need to add the safe option w/ memory copy.
