### PR TITLE
Use latest sonar-scanner and build-wrapper on runtime

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,10 +38,9 @@ jobs:
       project-name: OpenMPDK_dss-ecosystem
     secrets: inherit
   scan:
-    uses: OpenMPDK/DSS/.github/workflows/build-aws.yml@32e2895a71f6387a65435388406c414c68086216
+    uses: OpenMPDK/DSS/.github/workflows/build-aws.yml@master
     with:
       component: sonar-scanner
       project-name: OpenMPDK_dss-ecosystem
-      ext_image: sonarsource/sonar-scanner-cli:latest
     secrets: inherit
     needs: [unit, build]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,5 +42,6 @@ jobs:
     with:
       component: sonar-scanner
       project-name: OpenMPDK_dss-ecosystem
+      image: sonarsource/sonar-scanner-cli:latest
     secrets: inherit
     needs: [unit, build]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
       project-name: OpenMPDK_dss-ecosystem
     secrets: inherit
   scan:
-    uses: OpenMPDK/DSS/.github/workflows/build-aws.yml@velomatt-patch-1
+    uses: OpenMPDK/DSS/.github/workflows/build-aws.yml@32e2895a71f6387a65435388406c414c68086216
     with:
       component: sonar-scanner
       project-name: OpenMPDK_dss-ecosystem

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,6 @@ jobs:
     with:
       component: sonar-scanner
       project-name: OpenMPDK_dss-ecosystem
-      image: sonarsource/sonar-scanner-cli:latest
+      ext_image: sonarsource/sonar-scanner-cli:latest
     secrets: inherit
     needs: [unit, build]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
       project-name: OpenMPDK_dss-ecosystem
     secrets: inherit
   scan:
-    uses: OpenMPDK/DSS/.github/workflows/build-aws.yml@master
+    uses: OpenMPDK/DSS/.github/workflows/build-aws.yml@velomatt-patch-1
     with:
       component: sonar-scanner
       project-name: OpenMPDK_dss-ecosystem

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,9 +25,16 @@ stages:
 build dss_client:
   stage: build
   script:
+    # Download build wrapper from local SonarQube
+    - rm -rf /build-wrapper-linux-x86
+    - wget --no-verbose --content-disposition -E -c "$SONAR_HOST_URL/static/cpp/build-wrapper-linux-x86.zip"
+    - unzip -q build-wrapper-linux-x86.zip -d /
+    # Disable ssl verify from docker build env
     - git config --global http.sslVerify false
+    # Download RDD deps
     - ./dss_client/scripts/getrdddeps.sh
-    - build-wrapper-linux-x86-64 --out-dir bw-output/ ./dss_client/scripts/build.sh
+    # Build client with build-wrapper
+    - /build-wrapper-linux-x86/build-wrapper-linux-x86-64 --out-dir bw-output/ ./dss_client/scripts/build.sh
   artifacts:
     name: dss client build
     expire_in: 300 seconds
@@ -71,7 +78,12 @@ datamover unit test:
 
 sonar-scanner:
   stage: scan
-  script: sonar-scanner $SONAR_BRANCH -Dsonar.python.coverage.reportPaths=$PYTEST_COV_REPORT
+  script:
+    # Download sonar-scanner from local SonarQube
+    - rm -rf /sonar-scanner*
+    - wget --no-verbose --content-disposition -E -c "https://search.maven.org/remote_content?g=org.sonarsource.scanner.cli&a=sonar-scanner-cli&v=LATEST&c=linux&e=zip"
+    - unzip -q sonar-scanner-cli-*.zip -d /
+    - /sonar-scanner-*-linux/bin/sonar-scanner $SONAR_BRANCH -Dsonar.python.coverage.reportPaths=$PYTEST_COV_REPORT
   allow_failure: true
   dependencies:
     - datamover unit test

--- a/buildspec/dss-client.yml
+++ b/buildspec/dss-client.yml
@@ -13,10 +13,14 @@ phases:
     commands:
       # Download and extract RDD libs from prior dss-sdk target artifact for this branch
       - ./dss_client/scripts/getrdddeps.sh
+      # Download latest build-wrapper
+      - rm -rf /build-wrapper-linux-x86
+      - wget --no-verbose --content-disposition -E -c "https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip"
+      - unzip -q build-wrapper-linux-x86.zip -d /
   build:
     commands:
       # Build dss-client with Sonar build-wrapper for C/C++ static analysis
-      - build-wrapper-linux-x86-64 --out-dir bw-output ./dss_client/scripts/build.sh
+      - /build-wrapper-linux-x86/build-wrapper-linux-x86-64 --out-dir bw-output ./dss_client/scripts/build.sh
   post_build:
     commands:
       # Copy artifacts to branch dir if this is a merge

--- a/buildspec/sonar-scanner.yml
+++ b/buildspec/sonar-scanner.yml
@@ -11,7 +11,7 @@ phases:
   pre_build:
     commands:
       # Install aws-cli
-      apk add --no-cache aws-cli
+      - apk add --no-cache aws-cli
       # Download build wrapper output from dss-client build job
       - aws s3 cp --recursive "$DSSS3URI/cache/dss-ecosystem/$GITHUB_RUN_NUMBER/sonar" . --only-show-errors
       # Download unit test coverage report(s)

--- a/buildspec/sonar-scanner.yml
+++ b/buildspec/sonar-scanner.yml
@@ -25,6 +25,11 @@ phases:
       - sed -i -r "s|/codebuild/output/src[^/]+/src/github.com/OpenMPDK/dss-ecosystem|$CODEBUILD_SRC_DIR|g" .coverage-reports/*.xml
   build:
     commands:
+      - echo "***** DEBUGGING *****"
+      - pwd
+      - ls -al
+      - ls dss_client/
+      - ls dss_client/build/
       # Run sonar-scanner and ingest coverage report(s)
       - |
         sonar-scanner \

--- a/buildspec/sonar-scanner.yml
+++ b/buildspec/sonar-scanner.yml
@@ -28,11 +28,6 @@ phases:
       - rm -f sonar-scanner-cli*.zip
   build:
     commands:
-      - echo "***** DEBUGGING *****"
-      - pwd
-      - ls -al
-      - ls "$CODEBUILD_SRC_DIR/dss_client/"
-      - ls "$CODEBUILD_SRC_DIR/dss_client/build/"
       # Run sonar-scanner and ingest coverage report(s)
       - |
         /sonar-scanner-*-linux/bin/sonar-scanner \
@@ -40,7 +35,7 @@ phases:
           -Dsonar.host.url=https://sonarcloud.io \
           -Dsonar.pullrequest.github.summary_comment=true \
           -Dsonar.pullrequest.github.repository=OpenMPDK/dss-ecosystem \
-          -Dsonar.pullrequest.key=$(echo $GITHUB_REF | sed -r "s|^refs/pull/([[:digit:]]+)/.+|\1|g") \
+          -Dsonar.pullrequest.key=$(echo $GITHUB_REF | grep -oP "^refs/pull/\K[^/]+") \
           -Dsonar.pullrequest.base=$GITHUB_BASE_REF \
           -Dsonar.pullrequest.branch=$GITHUB_HEAD_REF \
           -Dsonar.python.coverage.reportPaths=.coverage-reports/coverage-datamover.xml

--- a/buildspec/sonar-scanner.yml
+++ b/buildspec/sonar-scanner.yml
@@ -32,7 +32,7 @@ phases:
           -Dsonar.host.url=https://sonarcloud.io \
           -Dsonar.pullrequest.github.summary_comment=true \
           -Dsonar.pullrequest.github.repository=OpenMPDK/dss-ecosystem \
-          -Dsonar.pullrequest.key=$(echo $GITHUB_REF | grep -oE "^refs/pull/\K[^/]+") \
+          -Dsonar.pullrequest.key=$(echo $GITHUB_REF | sed -r "s|^refs/pull/([[:digit:]]+)/.+|\1|g") \
           -Dsonar.pullrequest.base=$GITHUB_BASE_REF \
           -Dsonar.pullrequest.branch=$GITHUB_HEAD_REF \
           -Dsonar.python.coverage.reportPaths=.coverage-reports/coverage-datamover.xml

--- a/buildspec/sonar-scanner.yml
+++ b/buildspec/sonar-scanner.yml
@@ -10,8 +10,6 @@ env:
 phases:
   pre_build:
     commands:
-      # Install aws-cli
-      - apk add --no-cache aws-cli
       # Download build wrapper output from dss-client build job
       - aws s3 cp --recursive "$DSSS3URI/cache/dss-ecosystem/$GITHUB_RUN_NUMBER/sonar" . --only-show-errors
       # Download unit test coverage report(s)
@@ -23,6 +21,11 @@ phases:
       # replace the old CODEBUILD_SRC_DIR with the current one in bw-output and pytest cov
       - sed -i -r "s|/codebuild/output/src[^/]+/src/github.com/OpenMPDK/dss-ecosystem|$CODEBUILD_SRC_DIR|g" bw-output/build-wrapper-dump.json
       - sed -i -r "s|/codebuild/output/src[^/]+/src/github.com/OpenMPDK/dss-ecosystem|$CODEBUILD_SRC_DIR|g" .coverage-reports/*.xml
+      # Download the latest sonar-scanner
+      - rm -rf /sonar-scanner*
+      - wget --content-disposition -E -c "https://search.maven.org/remote_content?g=org.sonarsource.scanner.cli&a=sonar-scanner-cli&v=LATEST&c=linux&e=zip"
+      - unzip sonar-scanner-cli-*.zip -d /
+      - rm -f sonar-scanner-cli*.zip
   build:
     commands:
       - echo "***** DEBUGGING *****"
@@ -32,7 +35,7 @@ phases:
       - ls "$CODEBUILD_SRC_DIR/dss_client/build/"
       # Run sonar-scanner and ingest coverage report(s)
       - |
-        sonar-scanner \
+        /sonar-scanner-*-linux/bin/sonar-scanner \
           -Dsonar.branch.name="$([[ "$GITHUB_REF_NAME" != *"/merge" ]] && echo "$GITHUB_REF_NAME")" \
           -Dsonar.host.url=https://sonarcloud.io \
           -Dsonar.pullrequest.github.summary_comment=true \

--- a/buildspec/sonar-scanner.yml
+++ b/buildspec/sonar-scanner.yml
@@ -16,8 +16,6 @@ phases:
       - aws s3 cp --recursive "$DSSS3URI/cache/dss-ecosystem/$GITHUB_RUN_NUMBER/pytest" . --only-show-errors
       # Download dss_client/build
       - aws s3 cp --recursive "$DSSS3URI/cache/dss-ecosystem/$GITHUB_RUN_NUMBER/dss_client" dss_client/ --only-show-errors
-      # Temporary just to debug
-      - echo "$CODEBUILD_SRC_DIR"
       # replace the old CODEBUILD_SRC_DIR with the current one in bw-output and pytest cov
       - sed -i -r "s|/codebuild/output/src[^/]+/src/github.com/OpenMPDK/dss-ecosystem|$CODEBUILD_SRC_DIR|g" bw-output/build-wrapper-dump.json
       - sed -i -r "s|/codebuild/output/src[^/]+/src/github.com/OpenMPDK/dss-ecosystem|$CODEBUILD_SRC_DIR|g" .coverage-reports/*.xml

--- a/buildspec/sonar-scanner.yml
+++ b/buildspec/sonar-scanner.yml
@@ -32,7 +32,7 @@ phases:
           -Dsonar.host.url=https://sonarcloud.io \
           -Dsonar.pullrequest.github.summary_comment=true \
           -Dsonar.pullrequest.github.repository=OpenMPDK/dss-ecosystem \
-          -Dsonar.pullrequest.key=$(echo $GITHUB_REF | grep -oP "^refs/pull/\K[^/]+") \
+          -Dsonar.pullrequest.key=$(echo $GITHUB_REF | grep -oE "^refs/pull/\K[^/]+") \
           -Dsonar.pullrequest.base=$GITHUB_BASE_REF \
           -Dsonar.pullrequest.branch=$GITHUB_HEAD_REF \
           -Dsonar.python.coverage.reportPaths=.coverage-reports/coverage-datamover.xml

--- a/buildspec/sonar-scanner.yml
+++ b/buildspec/sonar-scanner.yml
@@ -23,8 +23,8 @@ phases:
       - sed -i -r "s|/codebuild/output/src[^/]+/src/github.com/OpenMPDK/dss-ecosystem|$CODEBUILD_SRC_DIR|g" .coverage-reports/*.xml
       # Download the latest sonar-scanner
       - rm -rf /sonar-scanner*
-      - wget --content-disposition -E -c "https://search.maven.org/remote_content?g=org.sonarsource.scanner.cli&a=sonar-scanner-cli&v=LATEST&c=linux&e=zip"
-      - unzip sonar-scanner-cli-*.zip -d /
+      - wget --no-verbose --content-disposition -E -c "https://search.maven.org/remote_content?g=org.sonarsource.scanner.cli&a=sonar-scanner-cli&v=LATEST&c=linux&e=zip"
+      - unzip -q sonar-scanner-cli-*.zip -d /
       - rm -f sonar-scanner-cli*.zip
   build:
     commands:

--- a/buildspec/sonar-scanner.yml
+++ b/buildspec/sonar-scanner.yml
@@ -10,6 +10,8 @@ env:
 phases:
   pre_build:
     commands:
+      # Install aws-cli
+      apk add --no-cache aws-cli
       # Download build wrapper output from dss-client build job
       - aws s3 cp --recursive "$DSSS3URI/cache/dss-ecosystem/$GITHUB_RUN_NUMBER/sonar" . --only-show-errors
       # Download unit test coverage report(s)

--- a/buildspec/sonar-scanner.yml
+++ b/buildspec/sonar-scanner.yml
@@ -28,8 +28,8 @@ phases:
       - echo "***** DEBUGGING *****"
       - pwd
       - ls -al
-      - ls dss_client/
-      - ls dss_client/build/
+      - ls "$CODEBUILD_SRC_DIR/dss_client/"
+      - ls "$CODEBUILD_SRC_DIR/dss_client/build/"
       # Run sonar-scanner and ingest coverage report(s)
       - |
         sonar-scanner \


### PR DESCRIPTION
The SonarCloud dependencies change too rapidly for us to bake them into the docker image. Plus SonarCloud and SonarQube dependencies will rapidly go out of sync. As a result, we need to download the sonar-scanner and build-wrapper every time we build.